### PR TITLE
Bump dependencies

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,3 @@
 {
-  "presets": ["@babel/preset-es2015"]
+  "presets": ["@babel/preset-env"]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased changes
 
+* Chores (via #8):
+  * Replaced deprecated `@babel/preset-es2015` with `@babel/preset-env`
+  * Updated babel related dependencies to stable Babel v7 release
+  * Updated other development dependencies (`mocha`, `all-contributors-cli`)
+
 ## 2.0.0-beta.0
 
 * Via [#3](https://github.com/newoga/babel-plugin-transform-replace-object-assign/pull/3):

--- a/package.json
+++ b/package.json
@@ -26,18 +26,18 @@
     "babel-plugin"
   ],
   "peerDependencies": {
-    "@babel/core": "^7.0.0-beta.42"
+    "@babel/core": "^7.0.0"
   },
   "dependencies": {
-    "@babel/helper-module-imports": "^7.0.0-beta.42"
+    "@babel/helper-module-imports": "^7.0.0"
   },
   "devDependencies": {
-    "all-contributors-cli": "^4.11.1",
-    "@babel/cli": "^7.0.0-beta.42",
-    "@babel/core": "^7.0.0-beta.42",
-    "@babel/preset-es2015": "^7.0.0-beta.42",
-    "@babel/register": "^7.0.0-beta.42",
+    "all-contributors-cli": "^5.4.0",
+    "@babel/cli": "^7.0.0",
+    "@babel/core": "^7.0.0",
+    "@babel/preset-env": "^7.0.0",
+    "@babel/register": "^7.0.0",
     "istanbul": "^0.4.2",
-    "mocha": "^5.0.4"
+    "mocha": "^5.2.0"
   }
 }


### PR DESCRIPTION
  * Replaced deprecated `@babel/preset-es2015` with `@babel/preset-env`
  * Updated babel related dependencies to stable Babel v7 release
  * Updated other development dependencies (`mocha`, `all-contributors-cli`)